### PR TITLE
Improve software installation user journey

### DIFF
--- a/software.md
+++ b/software.md
@@ -1,3 +1,11 @@
 # Software Installation
 
-To access Scratch 2.0, please visit https://scratch.mit.edu/.
+After updating your SD card to the latest build, you should also install the Chromium mods which will enable the Flash player software. Then reboot your Raspberry Pi t$
+
+To install the software you need, run the following commands in a terminal (hold `ctrl` + `alt` + `t`):
+
+```bash
+sudo apt-get install -y rpi-chromium-mods
+sudo reboot
+```
+

--- a/software.yml
+++ b/software.yml
@@ -1,1 +1,1 @@
-- Chromium
+- Chromium-mods

--- a/worksheet.md
+++ b/worksheet.md
@@ -1,24 +1,6 @@
 # Using Scratch 2.0 on Raspberry Pi
 
-In this resource you will find out how to use Scratch 2.0 on Raspberry Pi.
-
-## Updating your software
-
-You will need an up-to-date version of NOOBS to be able to use Scratch 2.0. This is because Scratch 2.0 requires a browser software plug-in from the latest release of NOOBS to allow Flash content to run.
-
-### Using a blank SD card
-
-Follow this guide to [get started with a blank SD card](https://www.raspberrypi.org/learning/software-guide/quickstart/).
-
-### Updating an existing installation
-You can follow this guide to [update an existing SD card](https://www.raspberrypi.org/learning/software-guide/update-sd-card/) to the newest build.
-
-After updating your SD card to the latest build, you should also install the Chromium mods which will enable the Flash player software. Then reboot your Raspberry Pi to allow the changes to take effect. Open a terminal window and type in the following commands:
-
-```
-sudo apt-get install -y rpi-chromium-mods
-sudo reboot
-```
+In this resource you will find out how to use Scratch 2.0 on Raspberry Pi
 
 ## Opening Scratch
 1. Open the Chromium web browser from the Internet menu.


### PR DESCRIPTION
Currently, when you click "What you will need" and then click "software installation" it give you a link to the scratch web site.  This is not consistent with other worksheets that actually tell you how to install the libraries required.

This PR moves the first step in the worksheet "Updating your software" to the "software installation" page so that it is consistent with other worksheets.
